### PR TITLE
[11.0][IMP] Compatibility with hr_maintenance

### DIFF
--- a/cb_maintenance/__manifest__.py
+++ b/cb_maintenance/__manifest__.py
@@ -12,6 +12,7 @@
     "depends": [
         "base_maintenance",
         "base_fontawesome",
+        "hr_maintenance",
         "maintenance_equipment_category_hierarchy",
         "maintenance_plan",
         "maintenance_location",
@@ -21,6 +22,7 @@
         "web_widget_child_selector",
     ],
     "data": [
+        "security/equipment.xml",
         "views/maintenance_equipment.xml",
         "views/maintenance_equipment_category.xml",
         "views/maintenance_request.xml",

--- a/cb_maintenance/security/equipment.xml
+++ b/cb_maintenance/security/equipment.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- HR officers and HR managers are NOT allowed to manage equipments -->
+    <record id="hr.group_hr_user" model="res.groups">
+        <field name="implied_ids" eval="[(4, ref('maintenance.group_equipment_manager'))]"/>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Añado la dependencia para asegurar que hr_maitnenance se instala antes que cb_maintenance y así poder arreglar fallos.
Creo que he arreglado lo de la security pero no puedo probarlo porque no se puede instalar...