### PR TITLE
[16.0][IMP] cb_maintenance: add total_purchase_amount

### DIFF
--- a/cb_maintenance/__manifest__.py
+++ b/cb_maintenance/__manifest__.py
@@ -20,6 +20,7 @@
         "maintenance_request_sequence",
         "maintenance_request_stage_transition",
         "maintenance_team_hierarchy",
+        "maintenance_request_purchase",
         "web_widget_open_tab",
         "base",
     ],

--- a/cb_maintenance/models/maintenance_request.py
+++ b/cb_maintenance/models/maintenance_request.py
@@ -47,6 +47,28 @@ class MaintenanceRequest(models.Model):
 
     external_link = fields.Char()
 
+    total_purchase_amount = fields.Monetary(
+        compute="_compute_total_purchase_amount",
+        store=True,
+        groups="purchase.group_purchase_user",
+    )
+
+    currency_id = fields.Many2one(
+        "res.currency", string="Currency", compute="_compute_currency", store=True
+    )
+
+    @api.depends("purchase_order_ids.amount_total")
+    def _compute_total_purchase_amount(self):
+        for record in self:
+            record.total_purchase_amount = sum(
+                record.purchase_order_ids.mapped("amount_total")
+            )
+
+    @api.depends("company_id")
+    def _compute_currency(self):
+        for record in self:
+            record.currency_id = record.company_id.currency_id
+
     # link_ocs = fields.Char(string="Link OCS") # TODO: Not sure if necessary
     @api.depends("close_datetime", "create_date")
     def _compute_hours_to_close(self):


### PR DESCRIPTION
incidencia related:
 ya no vemos el coste asociado a reparaciones. Esta herramienta nos es muy útil para evaluar el coste acumulado en equipamientos y tomar decisiones de reparación, pues acumulamos un listado muy largo de MRs y evaluar una a una es complicado. No se si sería posible de algun modo? 
 
 he creado el campo para que desde la vista pivot puedan jugar con él
 
 @etobella 